### PR TITLE
Thread 답장 기능 하위 호환 지원

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ android.applicationVariants.all {
                     from(file)
                     into(outputPath)
                     rename { fileName ->
-                        fileName.replace(file.name, "Iris.apk")
+                        fileName.replace(file.name, "Iris-${output.name}.apk")
                     }
                 }
             }

--- a/app/src/main/java/party/qwer/iris/PathUtils.kt
+++ b/app/src/main/java/party/qwer/iris/PathUtils.kt
@@ -3,7 +3,7 @@ package party.qwer.iris
 import java.io.File
 
 object PathUtils {
-    fun   getAppPath(): String {
+    fun getAppPath(): String {
         val androidUid = System.getenv("KAKAOTALK_APP_UID") ?: "0"
         val mirrorPath = "/data_mirror/data_ce/null/$androidUid/com.kakao.talk/"
         val defaultPath = "/data/data/com.kakao.talk/"


### PR DESCRIPTION
'26. 1. 28. 부터 카카오톡에 새롭게 추가된 thread 기능에 대한 하위호환성 담보 PR입니다.
## 0. 수정 사항
* Thread 답장인 경우 `attachment`의 `src_logId` 키에 `threadId`를 할당
* `attachment`에 Thread 답장임을 감지하게 하기 위해 `src_isThread` (boolean) 키 추가 (true = 스레드 답장피드, false = 스레드 아님)
* 기본 WebSocket 송신에서 `supplement` 컬럼 복호화 후 전달
 
## 1. 저장 구조
새로운 답장에서는 기존 `type`이 `26`에서 `1`로 변경되어 작동합니다. (Thread 기능 미지원 클라이언트에서 전송 시엔 `26`)
Thread 미지원 클라이언트(버전 코드 불명)에서 Thread 답장 메시지를 수신시에 `chat_logs` 테이블의 `supplement` 컬럼에 `user_id` 를 통해 암호화되어 아래와 같이 저장됩니다.
`threadId`는 **최초 답장 메시지의 `id` 컬럼 값입니다.**
`scope`는 아래와 같습니다.
1. ONLY_CHAT_ROOM
2. ONLY_THREAD_DETAIL
3. CHAT_ROOM_AND_THREAD_DETAIL

`supplement` 컬럼 복호화 후 예시)
```json
{"threadId":11212,"scope":3}
``` 

Thread 지원 클라이언트에서는 **`thread_id` 컬럼과 `scope` 컬럼에 `supplement` 컬럼에 저장되어 있는 값들이 나누어 저장**됩니다. (복호화 불필요)

## 2. 하위 호환성
현재 `threadId`는 기존 답장(type 26)에서의 `attachment` 내 `src_logId`와 비슷한 역할을 하고 있으며 (Thread의 parent chat), irispy-client에서도 attachment 내의 `src_logId`만을 이용해서 이전 채팅 정보를 불러오고 있습니다. 
```python
 def __get_reply_chat(self, message: Message):
        try:
            src_log_id = message.attachment['src_logId']
            query = "select * from chat_logs where id = ?"    
            src_record = self.api.query(query,[src_log_id])
            return src_record[0]
        except Exception as e:
            print(e)
            return None
```

기본적으로 `attachment`에 `src_isThread` 키를 추가하여 `true`인 경우 Thread 내 메시지, `false`인 경우 Thread 외 메시지임을 제3자 클라이언트에서도 구분할 수 있도록 합니다.

추가적으로,Iris 서버에서 아래의 조건이 충족할 때 `attachment`에 `threadId`를 `src_logId` 안에 임의로 주입하여 전송하면 호환성 문제가 발생하지 않을 수 있습니다.

구버전은 `thread_id` 컬럼 내가 비어있거나 `null`인 상태이므로, 이를 통해 구버전과 신버전 처리 방식을 분기합니다.

1. (구버전) 메시지 `type`이 1이고, 복호화된 `supplement` Object내에 `threadId`가 존재하며 `attachment`에 `src_logId`가 존재하지 않을 때
2. (신버전) 메시지 `type`이 1이고, `thread_id` 컬럼에 값이 존재할 때 

**websocket 기준 예시) (일반메시지)**
```json
{
   "msg":"XXXXXXXXX",
   "room":"XX",
   "sender":"XXXXXX",
   "json":{
      "_id":"43225",
      "id":"XXX",
      "type":"1",
      "chat_id":"XXXX",
      "thread_id":null,
      "scope":"1",
      "user_id":"XXXX",
      "message":"XXXXXX",
      "attachment":"{\"src_isThread\":false}",
      "created_at":"1769587436",
      "deleted_at":"0",
      "client_message_id":"...",
      "prev_id":"....",
      "referer":"0",
      "supplement":null,
      "v":"{\"notDecoded\":false,\"origin\":\"MSG\",\"c\":\"01-28 08:03:56\",\"modifyRevision\":0,\"isSingleDefaultEmoticon\":false,\"defaultEmoticonsCount\":0,\"isMine\":false,\"pushAlert\":false,\"enc\":31}"
   }
}
```
***websocket 기준 구버전 답장메시지 응답**
```json
{
   "msg":"XXX",
   "room":"XXX",
   "sender":"XXX",
   "json":{
      "_id":"43171",
      "id":"XXX",
      "type":"26",
      "chat_id":"XXX",
      "thread_id":null,
      "scope":"1",
      "user_id":"XXX",
      "message":"XXX",
      "attachment":"{\"src_isThread\":false,\"src_linkId\":309067423,\"src_userId\":10101010,\"src_logId\":10101010,\"src_type\":1,\"src_message\":\"이건 일반답장!... \"}",
      "created_at":"1769587109",
      "deleted_at":"0",
      "client_message_id":"60666512",
      "prev_id":"XXX",
      "referer":"0",
      "supplement":null,
      "v":"{\"notDecoded\":false,\"origin\":\"MSG\",\"c\":\"01-28 07:58:29\",\"modifyRevision\":0,\"isSingleDefaultEmoticon\":false,\"defaultEmoticonsCount\":0,\"isMine\":false,\"pushAlert\":false,\"enc\":31}"
   }
}
```
**Thread 답장 websocket 응답**
```json
{
   "msg":"xXX",
   "room":"xXX",
   "sender":"Iris",
   "json":{
      "_id":"43808",
      "id":"xXX",
      "type":"1",
      "chat_id":"xXX",
      "thread_id":"xXX",
      "scope":"2",
      "user_id":"xXX",
      "message":"무야포",
      "attachment":"{\"src_isThread\":true,\"src_logId\":110101010}",
      "created_at":"1769588759",
      "deleted_at":"0",
      "client_message_id":"1769565696",
      "prev_id":"xXX",
      "referer":"0",
      "supplement":"{\"scope\":2,\"threadId\":110101010}",
      "v":"{\"notDecoded\":false,\"origin\":\"MSG\",\"c\":\"01-28 08:25:59\",\"modifyRevision\":0,\"isSingleDefaultEmoticon\":false,\"defaultEmoticonsCount\":0,\"isMine\":true,\"pushAlert\":false,\"enc\":31}"
   }
}
````
