### PR TITLE
Fix silent row drops in DB polling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,4 +73,6 @@ dependencies {
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.okhttp)
+
+    testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/main/java/party/qwer/iris/KakaoDB.kt
+++ b/app/src/main/java/party/qwer/iris/KakaoDB.kt
@@ -57,12 +57,21 @@ class KakaoDB {
         return connection.rawQuery(sql, stringUserId).use { cursor ->
             if (cursor.moveToNext()) {
                 val encryptedName = cursor.getString(cursor.getColumnIndexOrThrow("name"))
-                val enc = cursor.getInt(cursor.getColumnIndexOrThrow("enc"))
+                if (encryptedName.isNullOrEmpty()) {
+                    return@use null
+                }
+
+                val encColumnIndex = cursor.getColumnIndex("enc")
+                if (encColumnIndex == -1 || cursor.isNull(encColumnIndex)) {
+                    return@use encryptedName
+                }
+
+                val enc = cursor.getInt(encColumnIndex)
 
                 try {
                     KakaoDecrypt.decrypt(enc, encryptedName, Configurable.botId)
                 } catch (e: Exception) {
-                    System.err.println("Decryption error in getNameOfUserId: $e");
+                    System.err.println("Decryption error in getNameOfUserId userId=$userId: $e")
                     encryptedName
                 }
             } else {

--- a/app/src/main/java/party/qwer/iris/LogCheckpointTracker.kt
+++ b/app/src/main/java/party/qwer/iris/LogCheckpointTracker.kt
@@ -1,0 +1,32 @@
+package party.qwer.iris
+
+import java.util.TreeSet
+
+internal class LogCheckpointTracker(initialCheckpoint: Long = 0L) {
+    private var checkpoint: Long = initialCheckpoint
+    private val completedBeyondCheckpoint = TreeSet<Long>()
+
+    fun checkpoint(): Long = checkpoint
+
+    fun reset(newCheckpoint: Long) {
+        checkpoint = newCheckpoint
+        completedBeyondCheckpoint.clear()
+    }
+
+    fun shouldSkip(logId: Long): Boolean {
+        return logId <= checkpoint || completedBeyondCheckpoint.contains(logId)
+    }
+
+    fun markCompleted(logId: Long): Long {
+        if (logId <= checkpoint) {
+            return checkpoint
+        }
+
+        completedBeyondCheckpoint.add(logId)
+        while (completedBeyondCheckpoint.remove(checkpoint + 1)) {
+            checkpoint += 1
+        }
+
+        return checkpoint
+    }
+}

--- a/app/src/main/java/party/qwer/iris/ObserverHelper.kt
+++ b/app/src/main/java/party/qwer/iris/ObserverHelper.kt
@@ -17,163 +17,212 @@ import kotlin.collections.set
 class ObserverHelper(
     private val db: KakaoDB, private val wsBroadcastFlow: MutableSharedFlow<String>
 ) {
-    private var lastLogId: Long = 0
+    private val checkpointTracker = LogCheckpointTracker()
     private val lastDecryptedLogs = LinkedList<Map<String, String?>>()
     private val httpRequestExecutor = Executors.newFixedThreadPool(8)
     private val okHttpClient = OkHttpClient()
 
     fun checkChange(db: KakaoDB) {
-        if (lastLogId == 0L) {
-            lastLogId = getLastLogIdFromDB()
-            println("Initial lastLogId: $lastLogId")
+        if (checkpointTracker.checkpoint() == 0L) {
+            val initialLogId = getLastLogIdFromDB()
+            checkpointTracker.reset(initialLogId)
+            println("Initial lastLogId: $initialLogId")
             return
         }
 
         val newLogCount = getNewLogCountFromDB()
+        if (newLogCount <= 0) {
+            return
+        }
 
-        if (newLogCount > 0) {
-            println("Detected $newLogCount new log(s). Processing...")
+        println("Detected $newLogCount new log(s). Processing...")
 
-            db.connection.rawQuery(
-                "SELECT * FROM chat_logs WHERE _id > ? ORDER BY _id ASC",
-                arrayOf(lastLogId.toString())
-            ).use { cursor ->
-                while (cursor.moveToNext()) {
-                    val columnNames = cursor.columnNames
-                    val currentLogId = cursor.getLong(columnNames.indexOf("_id"))
-
-                    if (currentLogId > lastLogId) {
-                        val v = JSONObject(cursor.getString(columnNames.indexOf("v")))
-                        val enc = v.getInt("enc")
-                        val origin = v.getString("origin")
-
-                        if (origin == "SYNCMSG" || origin == "MCHATLOGS") {
-                            lastLogId = currentLogId
-                            continue
-                        }
-
-                        val chatId = cursor.getLong(columnNames.indexOf("chat_id"))
-                        val userId = cursor.getLong(columnNames.indexOf("user_id"))
-
-                        var message = cursor.getString(columnNames.indexOf("message"))
-                        var attachment = cursor.getString(columnNames.indexOf("attachment"))
-                        val messageType = cursor.getString(columnNames.indexOf("type"))
-
-                        val threadId: String? = if (columnNames.indexOf("thread_id") != -1) {
-                            cursor.getString(columnNames.indexOf("thread_id"))
-                        } else {
-                            null
-                        }
-
-                        var supplement = "{}"
-                        try {
-                            supplement = cursor.getString(columnNames.indexOf("supplement"))
-                            if(supplement.isNotEmpty() && supplement != "{}")
-                                supplement = KakaoDecrypt.decrypt(enc, supplement, userId)
-                        } catch(_: Exception) {}
-
-                        try {
-                            if (message.isNotEmpty() && message != "{}") message =
-                                KakaoDecrypt.decrypt(enc, message, userId)
-                        } catch (e: Exception) {
-                            println("failed to decrypt message: $e")
-                        }
-
-                        try {
-                            if ((message.contains("선물") && messageType == "71") or (attachment == null)) {
-                                attachment = "{}"
-                            } else if (attachment.isNotEmpty() && attachment != "{}") {
-                                attachment =
-                                    KakaoDecrypt.decrypt(enc, attachment, userId)
-                            }
-                        } catch (e: Exception) {
-                            println("failed to decrypt attachment: $e")
-                        }
-
-                        storeDecryptedLog(cursor, message)
-
-                        lastLogId = currentLogId
-
-                        val raw = mutableMapOf<String, String?>()
-                        val advancedPlainSerialized = mutableMapOf<String, MutableMap<String, Any?>?>()
-
-                        for ((idx, columnName) in columnNames.withIndex()) {
-                            if (columnName == "message") {
-                                raw[columnName] = message
-                            } else if (columnName == "attachment") {
-                                raw[columnName] = attachment
-                                advancedPlainSerialized[columnName] = getStringJsonToMap(attachment)
-                                advancedPlainSerialized[columnName]!!["src_isThread"] = false
-                            } else if (columnName == "supplement") {
-                                raw["supplement"] = supplement
-                                advancedPlainSerialized[columnName] = getStringJsonToMap(supplement)
-                            } else {
-                                raw[columnName] = cursor.getString(idx)
-                            }
-                        }
-
-                        if (
-                            (threadId == null || threadId.isEmpty()) &&
-                            advancedPlainSerialized["supplement"]!!.getOrDefault("threadId", "") != ""
-                            &&
-                            advancedPlainSerialized["attachment"]!!.getOrDefault("src_logId", "") == ""
-                            &&
-                            messageType == "1"
-                        ) {
-                            advancedPlainSerialized["attachment"]!!["src_logId"] =
-                                advancedPlainSerialized["supplement"]!!.getOrDefault("threadId", "")
-                            advancedPlainSerialized["attachment"]!!["src_isThread"] = true
-                        } else if(threadId != null && messageType == "1") {
-                            advancedPlainSerialized["attachment"]!!["src_logId"] = threadId.toLong()
-                            advancedPlainSerialized["attachment"]!!["src_isThread"] = true
-                        }
-
-                        raw["attachment"] = JSONObject(advancedPlainSerialized["attachment"]!!).toString()
-
-                        val chatInfo = db.getChatInfo(chatId, userId)
-                        var roomName = chatInfo[0]
-                        var senderName = chatInfo[1]
-
-                        if (senderName.isNullOrEmpty()) {
-                            try {
-                                val rawKey = "person_${chatId}:${userId}"
-                                val md = MessageDigest.getInstance("SHA-256")
-                                val hashedId = md.digest(rawKey.toByteArray()).joinToString("") { "%02x".format(it) }
-
-                                val fallbackInfo = NamesDB.getName(hashedId)
-                                if (fallbackInfo != null) {
-                                    senderName = fallbackInfo.first
-                                    if (roomName.isNullOrEmpty()) {
-                                        roomName = fallbackInfo.second
-                                    }
-                                }
-                            } catch (e: Exception) {
-                                e.printStackTrace()
-                            }
-                        }
-
-                        val data = JSONObject(
-                            mapOf(
-                                "msg" to message,
-                                "room" to roomName,
-                                "sender" to senderName,
-                                "json" to raw
-                            )
-                        ).toString()
-
-                        runBlocking {
-                            wsBroadcastFlow.emit(data)
-                        }
-
-                        if (Configurable.webServerEndpoint.isNotEmpty()) {
-                            httpRequestExecutor.execute {
-                                sendPostRequest(data)
-                            }
-                        }
-                    }
-                }
+        db.connection.rawQuery(
+            "SELECT * FROM chat_logs WHERE _id > ? ORDER BY _id ASC",
+            arrayOf(checkpointTracker.checkpoint().toString())
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                processCursorRow(cursor)
             }
         }
+    }
+
+    private fun processCursorRow(cursor: Cursor) {
+        val columnNames = cursor.columnNames
+        val currentLogId = cursor.getLong(columnNames.indexOf("_id"))
+
+        if (checkpointTracker.shouldSkip(currentLogId)) {
+            return
+        }
+
+        val chatId = cursor.getLongOrNull(columnNames, "chat_id")
+        val userId = cursor.getLongOrNull(columnNames, "user_id")
+        val messageType = cursor.getStringOrNull(columnNames, "type")
+        val message = cursor.getStringOrNull(columnNames, "message")
+        val attachment = cursor.getStringOrNull(columnNames, "attachment")
+        val supplement = cursor.getStringOrNull(columnNames, "supplement")
+        val metadata = RowMetadata(
+            logId = currentLogId,
+            chatId = chatId,
+            userId = userId,
+            messageType = messageType,
+            messageLength = message?.length ?: 0,
+            attachmentLength = attachment?.length ?: 0,
+            supplementLength = supplement?.length ?: 0
+        )
+
+        try {
+            processRow(cursor, columnNames, metadata)
+            checkpointTracker.markCompleted(currentLogId)
+        } catch (e: Exception) {
+            logRowFailure(metadata, "row", e)
+        }
+    }
+
+    private fun processRow(cursor: Cursor, columnNames: Array<String>, metadata: RowMetadata) {
+        val vRaw = cursor.getStringOrNull(columnNames, "v") ?: "{}"
+        val v = try {
+            JSONObject(vRaw)
+        } catch (e: Exception) {
+            logRowFailure(metadata, "v_parse", e)
+            JSONObject("{}")
+        }
+        val enc = v.optInt("enc", 0)
+        val origin = v.optString("origin", "")
+
+        if (origin == "SYNCMSG" || origin == "MCHATLOGS") {
+            checkpointTracker.markCompleted(metadata.logId)
+            return
+        }
+
+        val chatId = metadata.chatId ?: 0L
+        val userId = metadata.userId ?: 0L
+        val messageType = metadata.messageType ?: ""
+
+        var message = cursor.getStringOrNull(columnNames, "message") ?: ""
+        var attachment = cursor.getStringOrNull(columnNames, "attachment") ?: "{}"
+        val threadId = cursor.getStringOrNull(columnNames, "thread_id")
+
+        var supplement = "{}"
+        try {
+            supplement = cursor.getStringOrNull(columnNames, "supplement") ?: "{}"
+            if (supplement.isNotEmpty() && supplement != "{}") {
+                supplement = KakaoDecrypt.decrypt(enc, supplement, userId)
+            }
+        } catch (e: Exception) {
+            logRowFailure(metadata, "supplement_decrypt", e)
+            supplement = "{}"
+        }
+
+        try {
+            if (message.isNotEmpty() && message != "{}") {
+                message = KakaoDecrypt.decrypt(enc, message, userId)
+            }
+        } catch (e: Exception) {
+            logRowFailure(metadata, "message_decrypt", e)
+        }
+
+        try {
+            if ((message.contains("선물") && messageType == "71") || attachment == "null") {
+                attachment = "{}"
+            } else if (attachment.isNotEmpty() && attachment != "{}") {
+                attachment = KakaoDecrypt.decrypt(enc, attachment, userId)
+            }
+        } catch (e: Exception) {
+            logRowFailure(metadata, "attachment_decrypt", e)
+            attachment = "{}"
+        }
+
+        storeDecryptedLog(cursor, message)
+
+        val raw = mutableMapOf<String, String?>()
+        val attachmentMap = getStringJsonToMap(attachment, metadata, "attachment_parse").apply {
+            this["src_isThread"] = false
+        }
+        val supplementMap = getStringJsonToMap(supplement, metadata, "supplement_parse")
+
+        for ((idx, columnName) in columnNames.withIndex()) {
+            when (columnName) {
+                "message" -> raw[columnName] = message
+                "attachment" -> raw[columnName] = attachment
+                "supplement" -> raw[columnName] = supplement
+                else -> raw[columnName] = cursor.getString(idx)
+            }
+        }
+
+        if (
+            threadId.isNullOrEmpty() &&
+            supplementMap.getOrDefault("threadId", "") != "" &&
+            attachmentMap.getOrDefault("src_logId", "") == "" &&
+            messageType == "1"
+        ) {
+            attachmentMap["src_logId"] = supplementMap.getOrDefault("threadId", "")
+            attachmentMap["src_isThread"] = true
+        } else if (!threadId.isNullOrEmpty() && messageType == "1") {
+            attachmentMap["src_logId"] = threadId.toLongOrNull() ?: threadId
+            attachmentMap["src_isThread"] = true
+        }
+
+        raw["attachment"] = JSONObject(attachmentMap as Map<*, *>).toString()
+        raw["supplement"] = JSONObject(supplementMap as Map<*, *>).toString()
+
+        val (roomName, senderName) = resolveChatInfo(chatId, userId, metadata)
+        val data = JSONObject(
+            mapOf(
+                "msg" to message,
+                "room" to roomName,
+                "sender" to senderName,
+                "json" to raw
+            )
+        ).toString()
+
+        runBlocking {
+            wsBroadcastFlow.emit(data)
+        }
+
+        if (Configurable.webServerEndpoint.isNotEmpty()) {
+            httpRequestExecutor.execute {
+                sendPostRequest(data)
+            }
+        }
+    }
+
+    private fun resolveChatInfo(chatId: Long, userId: Long, metadata: RowMetadata): Pair<String, String> {
+        var roomName: String? = null
+        var senderName: String? = null
+
+        try {
+            val chatInfo = db.getChatInfo(chatId, userId)
+            roomName = chatInfo.getOrNull(0)
+            senderName = chatInfo.getOrNull(1)
+        } catch (e: Exception) {
+            logRowFailure(metadata, "chat_info_lookup", e)
+        }
+
+        if (senderName.isNullOrEmpty()) {
+            try {
+                val rawKey = "person_${chatId}:${userId}"
+                val md = MessageDigest.getInstance("SHA-256")
+                val hashedId = md.digest(rawKey.toByteArray()).joinToString("") { "%02x".format(it) }
+
+                val fallbackInfo = NamesDB.getName(hashedId)
+                if (fallbackInfo != null) {
+                    senderName = fallbackInfo.first
+                    if (roomName.isNullOrEmpty()) {
+                        roomName = fallbackInfo.second
+                    }
+                }
+            } catch (e: Exception) {
+                logRowFailure(metadata, "namesdb_lookup", e)
+            }
+        }
+
+        val fallbackSender = senderName?.takeIf { it.isNotBlank() } ?: "<unknown:$userId>"
+        val fallbackRoom = roomName?.takeIf { it.isNotBlank() }
+            ?: senderName?.takeIf { it.isNotBlank() }
+            ?: "chat:$chatId"
+
+        return fallbackRoom to fallbackSender
     }
 
     private fun getLastLogIdFromDB(): Long {
@@ -181,24 +230,37 @@ class ObserverHelper(
         return lastLog["_id"]?.toLongOrNull() ?: 0
     }
 
-    private fun getStringJsonToMap(data: String?): MutableMap<String, Any?> {
-        if(data == null) return HashMap()
-        val object_ = JSONObject(data)
-        val map: MutableMap<String, Any?> = HashMap()
-
-        val keys: MutableIterator<String> = object_.keys()
-        while (keys.hasNext()) {
-            val key = keys.next()
-            val value: Any? = object_.get(key)
-            map[key] = value
+    private fun getStringJsonToMap(
+        data: String?,
+        metadata: RowMetadata,
+        stage: String
+    ): MutableMap<String, Any?> {
+        if (data.isNullOrBlank() || data == "{}") {
+            return HashMap()
         }
 
-        return map
+        return try {
+            val object_ = JSONObject(data)
+            val map: MutableMap<String, Any?> = HashMap()
+
+            val keys: MutableIterator<String> = object_.keys()
+            while (keys.hasNext()) {
+                val key = keys.next()
+                val value: Any? = object_.get(key)
+                map[key] = value
+            }
+
+            map
+        } catch (e: Exception) {
+            logRowFailure(metadata, stage, e)
+            HashMap()
+        }
     }
 
     private fun getNewLogCountFromDB(): Int {
         val res = db.executeQuery(
-            "select count(*) as cnt from chat_logs where _id > ?", arrayOf(lastLogId.toString())
+            "select count(*) as cnt from chat_logs where _id > ?",
+            arrayOf(checkpointTracker.checkpoint().toString())
         )
         return res[0]["cnt"]?.toIntOrNull() ?: 0
     }
@@ -218,42 +280,74 @@ class ObserverHelper(
         }
     }
 
-    private fun sendPostRequest(jsonData: String) {
-        val url = Configurable.webServerEndpoint
-        println("Sending HTTP POST request to: $url")
-        println("JSON Data being sent: $jsonData")
-
-        val mediaType = "application/json; charset=utf-8".toMediaType()
-        val requestBody = jsonData.toRequestBody(mediaType)
-
-        val request = Request.Builder()
-            .url(url)
-            .post(requestBody)
-            .header("Content-Type", "application/json")
-            .header("Accept", "application/json")
-            .build()
-
-        try {
-            okHttpClient.newCall(request).execute().use { response ->
-                val responseCode = response.code
-                println("HTTP Response Code: $responseCode")
-
-                if (response.isSuccessful) {
-                    val responseBody = response.body?.string()
-                    println("HTTP Response Body: $responseBody")
-                } else {
-                    System.err.println("HTTP Error Response: $responseCode - ${response.message}")
-                }
-            }
-        } catch (e: IOException) {
-            System.err.println("Error sending POST request: " + e.message)
-        }
+    @Synchronized
+    fun getRecentDecryptedLogs(limit: Int): List<Map<String, String?>> {
+        return lastDecryptedLogs.take(limit)
     }
 
     val lastChatLogs: List<Map<String, String?>>
-        get() = lastDecryptedLogs
+        @Synchronized get() = lastDecryptedLogs
+
+    private fun sendPostRequest(jsonData: String) {
+        try {
+            val requestBody = jsonData.toRequestBody("application/json; charset=utf-8".toMediaType())
+            val request = Request.Builder()
+                .url(Configurable.webServerEndpoint)
+                .post(requestBody)
+                .build()
+
+            okHttpClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    println("Failed to send POST request. Response code: ${response.code}")
+                }
+            }
+        } catch (e: IOException) {
+            println("Error sending POST request: ${e.message}")
+        }
+    }
+
+    private fun logRowFailure(metadata: RowMetadata, stage: String, error: Exception) {
+        System.err.println(
+            "Row processing failed" +
+                " _id=${metadata.logId}" +
+                " chat_id=${metadata.chatId ?: "null"}" +
+                " user_id=${metadata.userId ?: "null"}" +
+                " type=${metadata.messageType ?: "null"}" +
+                " message_len=${metadata.messageLength}" +
+                " attachment_len=${metadata.attachmentLength}" +
+                " supplement_len=${metadata.supplementLength}" +
+                " stage=$stage" +
+                " error=${error.javaClass.simpleName}:${error.message}"
+        )
+    }
+
+    private data class RowMetadata(
+        val logId: Long,
+        val chatId: Long?,
+        val userId: Long?,
+        val messageType: String?,
+        val messageLength: Int,
+        val attachmentLength: Int,
+        val supplementLength: Int
+    )
 
     companion object {
         private const val MAX_LOGS_STORED = 50
     }
+}
+
+private fun Cursor.getStringOrNull(columnNames: Array<String>, columnName: String): String? {
+    val index = columnNames.indexOf(columnName)
+    if (index == -1 || isNull(index)) {
+        return null
+    }
+    return getString(index)
+}
+
+private fun Cursor.getLongOrNull(columnNames: Array<String>, columnName: String): Long? {
+    val index = columnNames.indexOf(columnName)
+    if (index == -1 || isNull(index)) {
+        return null
+    }
+    return getLong(index)
 }

--- a/app/src/test/java/party/qwer/iris/LogCheckpointTrackerTest.kt
+++ b/app/src/test/java/party/qwer/iris/LogCheckpointTrackerTest.kt
@@ -1,0 +1,43 @@
+package party.qwer.iris
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LogCheckpointTrackerTest {
+    @Test
+    fun `does not advance checkpoint across a failed gap`() {
+        val tracker = LogCheckpointTracker(initialCheckpoint = 10L)
+
+        tracker.markCompleted(12L)
+
+        assertEquals(10L, tracker.checkpoint())
+        assertTrue(tracker.shouldSkip(12L))
+        assertFalse(tracker.shouldSkip(11L))
+    }
+
+    @Test
+    fun `advances checkpoint once the missing row succeeds`() {
+        val tracker = LogCheckpointTracker(initialCheckpoint = 10L)
+
+        tracker.markCompleted(12L)
+        tracker.markCompleted(11L)
+
+        assertEquals(12L, tracker.checkpoint())
+        assertTrue(tracker.shouldSkip(11L))
+        assertTrue(tracker.shouldSkip(12L))
+    }
+
+    @Test
+    fun `reset clears pending completions`() {
+        val tracker = LogCheckpointTracker(initialCheckpoint = 10L)
+
+        tracker.markCompleted(12L)
+        tracker.reset(20L)
+
+        assertEquals(20L, tracker.checkpoint())
+        assertTrue(tracker.shouldSkip(12L))
+        assertFalse(tracker.shouldSkip(21L))
+    }
+}


### PR DESCRIPTION
## Summary
- add a contiguous checkpoint tracker so a later successful row cannot advance past an earlier failed row
- make row processing resilient with fallback attachment/supplement/chat info handling and row-level failure logs
- harden `getNameOfUserId()` null handling and add regression tests for checkpoint behavior

## Validation
- `JAVA_HOME=/Applications/Android Studio.app/Contents/jbr/Contents/Home ANDROID_HOME=/Users/munawiki/Library/Android/sdk ANDROID_SDK_ROOT=/Users/munawiki/Library/Android/sdk PATH=/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin:$PATH ./gradlew testDebugUnitTest`
- `JAVA_HOME=/Applications/Android Studio.app/Contents/jbr/Contents/Home ANDROID_HOME=/Users/munawiki/Library/Android/sdk ANDROID_SDK_ROOT=/Users/munawiki/Library/Android/sdk PATH=/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin:$PATH ./gradlew assembleDebug`

Closes #119